### PR TITLE
force pyo with jack in audio backend

### DIFF
--- a/mandarin_exp.py
+++ b/mandarin_exp.py
@@ -11,6 +11,10 @@ If you publish work using this script please cite the PsychoPy publications:
 """
 
 from __future__ import absolute_import, division
+from psychopy import prefs
+prefs.general['audioLib'] = ['pyo']
+prefs.general['audioDriver'] = [u'jack']
+# start jack in bash with `jackd -r -d alsa -r 44100`
 from psychopy import locale_setup, sound, gui, visual, core, data, event, logging
 from psychopy.constants import (NOT_STARTED, STARTED, PLAYING, PAUSED,
                                 STOPPED, FINISHED, PRESSED, RELEASED, FOREVER)


### PR DESCRIPTION
You need to start jackd on debian and then this should run and play the sounds.

jackd can be started with

```
jackd -r -d alsa -r 44100
```

in the bash, which works me, but there might be some other good options too.


If jack cannot start because the audio device is still busy, you might be able to collect the information which program it is with:

```
fuser -v /dev/snd/pcmC0D0p
```

either manually close all programs or kill them with:

```
fuser -k /dev/snd/pcmC0D0p
```

Some resources
* https://github.com/overtone/overtone/wiki/Installing-and-starting-jack
* https://wiki.archlinux.org/index.php/PulseAudio/Examples#PulseAudio_through_JACK
